### PR TITLE
Fix clients entering the game even when `SendPlayerQuit` was called

### DIFF
--- a/GameServer/packets/Server/PacketLib168.cs
+++ b/GameServer/packets/Server/PacketLib168.cs
@@ -834,6 +834,9 @@ namespace DOL.GS.PacketHandler
 
 		public virtual void SendPlayerQuit(bool totalOut)
 		{
+			// Prevents the client from entering the game when this is called when the player is changing region.
+			m_gameClient.PacketProcessor.ClearPacketQueues();
+
 			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Quit)))
 			{
 				pak.WriteByte((byte)(totalOut ? 0x01 : 0x00));

--- a/GameServer/packets/Server/PacketProcessor.cs
+++ b/GameServer/packets/Server/PacketProcessor.cs
@@ -1,22 +1,3 @@
-/*
- * DAWN OF LIGHT - The first free open source DAoC server emulator
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- *
- */
-
 #define LOGACTIVESTACKS
 
 using System;
@@ -378,6 +359,12 @@ namespace DOL.GS.PacketHandler
 
                 GameServer.Instance.Disconnect(m_client);
             }
+        }
+
+        public void ClearPacketQueues()
+        {
+            TcpQueue.Clear();
+            m_udpQueue.Clear(); // Probably doesn't do anything. 'TcpQueue' and 'm_udpQueue' currently serve a different purpose.
         }
 
         /// <summary>


### PR DESCRIPTION
This would put the player in a seemingly desynchronized state, and happens because for some reason the client ignores `SendPlayerQuit` when changing region.