### PR TITLE
More commands and healing code

### DIFF
--- a/GameServer/custom/MimicNPC/ClassSpecs/Albion/Armsman.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Albion/Armsman.cs
@@ -14,7 +14,7 @@ namespace DOL.GS.Scripts
 
     public class ArmsmanSpec : MimicSpec
     {
-        public ArmsmanSpec()
+        public ArmsmanSpec(eSpecType spec)
         {
             SpecName = "ArmsmanSpec";
 
@@ -45,7 +45,16 @@ namespace DOL.GS.Scripts
             else
                 WeaponTwoType = eObjectType.TwoHandedWeapon;
 
-            int randVariance = Util.Random(5);
+            var randVariance = spec switch
+            {
+                eSpecType.OneHanded => Util.Random(0, 1),
+                eSpecType.OneHandAndShield => Util.Random(0, 1),
+                eSpecType.OneHandHybrid => 2,
+                eSpecType.TwoHandAndShield => Util.Random(3, 4),
+                eSpecType.TwoHandHybrid => Util.Random(3, 4),
+                eSpecType.TwoHanded => 5,
+                _ => Util.Random(5),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Albion/Cabalist.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Albion/Cabalist.cs
@@ -8,14 +8,20 @@
 
     public class CabalistSpec : MimicSpec
     {
-        public CabalistSpec()
+        public CabalistSpec(eSpecType spec)
         {
             SpecName = "CabalistSpec";
 
             WeaponOneType = eObjectType.Staff;
             Is2H = true;
 
-            int randVariance = Util.Random(20);
+            var randVariance = spec switch
+            {
+                eSpecType.MatterCab => Util.Random(0, 6),
+                eSpecType.BodyCab => Util.Random(7, 13),
+                eSpecType.SpiritCab => Util.Random(14, 20),
+                _ => Util.Random(20),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Albion/Cleric.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Albion/Cleric.cs
@@ -10,13 +10,19 @@ namespace DOL.GS.Scripts
 
     public class ClericSpec : MimicSpec
     {
-        public ClericSpec()
+        public ClericSpec(eSpecType spec)
         {
             SpecName = "ClericSpec";
 
             WeaponOneType = eObjectType.CrushingWeapon;
 
-            int randVariance = Util.Random(7);
+            var randVariance = spec switch
+            {
+                eSpecType.EnhanceCleric => Util.Random(0, 3),
+                eSpecType.RejuvCleric => Util.Random(4, 5),
+                eSpecType.SmiteCleric => Util.Random(6, 7),
+                _ => Util.Random(7),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Albion/Friar.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Albion/Friar.cs
@@ -12,14 +12,20 @@ namespace DOL.GS.Scripts
 
     public class FriarSpec : MimicSpec
     {
-        public FriarSpec()
+        public FriarSpec(eSpecType spec)
         {
             SpecName = "FriarSpec";
 
             WeaponOneType = eObjectType.Staff;
             Is2H = true;
 
-            int randVariance = Util.Random(8);
+            var randVariance = spec switch
+            {
+                eSpecType.StaffFriar => Util.Random(0, 4),
+                eSpecType.RejuvFriar => Util.Random(5, 7),
+                eSpecType.EnhanceFriar => 8,
+                _ => Util.Random(8),
+            };
 
             switch (randVariance)
             {
@@ -80,7 +86,7 @@ namespace DOL.GS.Scripts
                 break;
 
                 case 7:
-                SpecType = eSpecType.EnhanceFriar;
+                SpecType = eSpecType.RejuvFriar;
                 Add(Specs.Rejuvenation, 44, 0.8f);
                 Add(Specs.Enhancement, 49, 0.5f);
                 Add(Specs.Parry, 4, 0.1f);

--- a/GameServer/custom/MimicNPC/ClassSpecs/Albion/Mercenary.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Albion/Mercenary.cs
@@ -10,7 +10,7 @@ namespace DOL.GS.Scripts
 
     public class MercenarySpec : MimicSpec
     {
-        public MercenarySpec()
+        public MercenarySpec(eSpecType spec)
         {
             SpecName = "MercenarySpec";
 
@@ -23,7 +23,12 @@ namespace DOL.GS.Scripts
                 case 2: WeaponOneType = eObjectType.CrushingWeapon; break;
             }
 
-            int randVariance = Util.Random(3);
+            var randVariance = spec switch
+            {
+                eSpecType.DualWield => Util.Random(0, 2),
+                eSpecType.DualWieldAndShield => 3,
+                _ => Util.Random(3),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Albion/Paladin.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Albion/Paladin.cs
@@ -10,7 +10,7 @@ namespace DOL.GS.Scripts
 
     public class PaladinSpec : MimicSpec
     {
-        public PaladinSpec()
+        public PaladinSpec(eSpecType spec)
         {
             SpecName = "PaladinSpec";
 
@@ -36,7 +36,14 @@ namespace DOL.GS.Scripts
 
             WeaponTwoType = eObjectType.TwoHandedWeapon;
 
-            int randVariance = Util.Random(7);
+            var randVariance = spec switch
+            {
+                eSpecType.TwoHanded => Util.Random(0, 1),
+                eSpecType.TwoHandHybrid => Util.Random(0, 1),
+                eSpecType.OneHanded => Util.Random(2, 7),
+                eSpecType.OneHandAndShield => Util.Random(2, 7),
+                _ => Util.Random(7),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Albion/Sorcerer.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Albion/Sorcerer.cs
@@ -10,14 +10,19 @@ namespace DOL.GS.Scripts
 
     public class SorcererSpec : MimicSpec
     {
-        public SorcererSpec()
+        public SorcererSpec(eSpecType spec)
         {
             SpecName = "SorcererSpec";
 
             WeaponOneType = eObjectType.Staff;
             Is2H = true;
 
-            int randVariance = Util.Random(6);
+            var randVariance = spec switch
+            {
+                eSpecType.MindSorc => Util.Random(0, 3),
+                eSpecType.BodySorc => Util.Random(4, 6),
+                _ => Util.Random(6),
+            };
                     
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Albion/Theurgist.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Albion/Theurgist.cs
@@ -10,14 +10,20 @@ namespace DOL.GS.Scripts
 
     public class TheurgistSpec : MimicSpec
     {
-        public TheurgistSpec()
+        public TheurgistSpec(eSpecType  spec)
         {
             SpecName = "TheurgistSpec";
 
             WeaponOneType = eObjectType.Staff;
             Is2H = true;
 
-            int randVariance = Util.Random(2);
+            var randVariance = spec switch
+            {
+                eSpecType.AirTheur => 0,
+                eSpecType.IceTheur => 1,
+                eSpecType.EarthTheur => 2,
+                _ => Util.Random(2),
+            };
             
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Albion/Wizard.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Albion/Wizard.cs
@@ -11,14 +11,20 @@ namespace DOL.GS.Scripts
 
     public class WizardSpec : MimicSpec
     {
-        public WizardSpec()
+        public WizardSpec(eSpecType spec)
         {
             SpecName = "WizardSpec";
 
             WeaponOneType = eObjectType.Staff;
             Is2H = true;
 
-            int randVariance = Util.Random(2);
+            var randVariance = spec switch
+            {
+                eSpecType.EarthWiz => 0,
+                eSpecType.IceWiz => 1,
+                eSpecType.FireWiz => 2,
+                _ => Util.Random(2),
+            };
             
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Blademaster.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Blademaster.cs
@@ -10,7 +10,7 @@ namespace DOL.GS.Scripts
 
     public class BlademasterSpec : MimicSpec
     {
-        public BlademasterSpec()
+        public BlademasterSpec(eSpecType spec)
         {
             SpecName = "BlademasterSpec";
             Is2H = false;
@@ -24,7 +24,12 @@ namespace DOL.GS.Scripts
                 case 2: WeaponOneType = eObjectType.Blunt; break;
             }
 
-            int randVariance = Util.Random(2);
+            var randVariance = spec switch
+            {
+                eSpecType.DualWield => Util.Random(1),
+                eSpecType.DualWieldAndShield => 2,
+                _ => Util.Random(2),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Champion.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Champion.cs
@@ -10,7 +10,7 @@ namespace DOL.GS.Scripts
 
     public class ChampionSpec : MimicSpec
     {
-        public ChampionSpec()
+        public ChampionSpec(eSpecType spec)
         {
             SpecName = "ChampionSpec";
 
@@ -25,7 +25,13 @@ namespace DOL.GS.Scripts
 
             WeaponTwoType = eObjectType.LargeWeapons;
 
-            int randVariance = Util.Random(3);
+            var randVariance = spec switch
+            {
+                eSpecType.OneHanded => Util.Random(0, 1),
+                eSpecType.OneHandAndShield => Util.Random(0, 1),
+                eSpecType.TwoHanded => 2,
+                _ => Util.Random(3),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Druid.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Druid.cs
@@ -10,7 +10,7 @@ namespace DOL.GS.Scripts
 
     public class DruidSpec : MimicSpec
     {
-        public DruidSpec()
+        public DruidSpec(eSpecType spec)
         {
             SpecName = "DruidSpec";
             Is2H = false;
@@ -23,7 +23,13 @@ namespace DOL.GS.Scripts
                 case 1: WeaponOneType = eObjectType.Blunt; break;
             }
 
-            int randVariance = Util.Random(6);
+            var randVariance = spec switch
+            {
+                eSpecType.NurtureDruid => Util.Random(3),
+                eSpecType.RegrowthDruid => 4,
+                eSpecType.NatureDruid => Util.Random(5, 6),
+                _ => Util.Random(6),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Eldritch.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Eldritch.cs
@@ -10,14 +10,20 @@ namespace DOL.GS.Scripts
 
     public class EldritchSpec : MimicSpec
     {
-        public EldritchSpec()
+        public EldritchSpec(eSpecType spec)
         {
             SpecName = "EldritchSpec";
 
             WeaponOneType = eObjectType.Staff;
             Is2H = true;
 
-            int randVariance = Util.Random(11);
+            var randVariance = spec switch
+            {
+                eSpecType.LightEld => Util.Random(0, 3),
+                eSpecType.ManaEld => Util.Random(4, 7),
+                eSpecType.VoidEld => Util.Random(8, 11),
+                _ => Util.Random(11),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Enchanter.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Enchanter.cs
@@ -10,14 +10,19 @@ namespace DOL.GS.Scripts
 
     public class EnchanterSpec : MimicSpec
     {
-        public EnchanterSpec()
+        public EnchanterSpec(eSpecType spec)
         {
             SpecName = "EnchanterSpec";
 
             WeaponOneType = eObjectType.Staff;
             Is2H = true;
 
-            int randVariance = Util.Random(3);
+            var randVariance = spec switch
+            {
+                eSpecType.ManaEnchanter => Util.Random(0, 1),
+                eSpecType.LightEnchanter => Util.Random(2, 3),
+                _ => Util.Random(3),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Hero.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Hero.cs
@@ -10,7 +10,7 @@ namespace DOL.GS.Scripts
 
     public class HeroSpec : MimicSpec
     {
-        public HeroSpec()
+        public HeroSpec(eSpecType spec)
         {
             SpecName = "HeroSpec";
             Is2H = false;
@@ -31,7 +31,15 @@ namespace DOL.GS.Scripts
             else
                 WeaponTwoType = eObjectType.LargeWeapons;
 
-            int randVariance = Util.Random(4);
+            var randVariance = spec switch
+            {
+                eSpecType.OneHanded => 0,
+                eSpecType.OneHandAndShield => 0,
+                eSpecType.TwoHanded => Util.Random(1, 4),
+                eSpecType.TwoHandAndShield => Util.Random(1, 4),
+                eSpecType.TwoHandHybrid => Util.Random(1, 4),
+                _ => Util.Random(4),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Mentalist.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Mentalist.cs
@@ -10,15 +10,21 @@ namespace DOL.GS.Scripts
 
     public class MentalistSpec : MimicSpec
     {
-        public MentalistSpec()
+        public MentalistSpec(eSpecType spec)
         {
             SpecName = "MentalistSpec";
 
             WeaponOneType = eObjectType.Staff;
             Is2H = true;
 
-            int randVariance = Util.Random(13);
-            
+            var randVariance = spec switch
+            {
+                eSpecType.LightMenta => Util.Random(0, 4),
+                eSpecType.ManaMenta => Util.Random(5, 9),
+                eSpecType.MentaMenta => Util.Random(10, 13),
+                _ => Util.Random(13),
+            };
+
             switch (randVariance)
             {
                 case 0:

--- a/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Warden.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Hibernia/Warden.cs
@@ -10,7 +10,7 @@ namespace DOL.GS.Scripts
 
     public class WardenSpec : MimicSpec
     {
-        public WardenSpec()
+        public WardenSpec(eSpecType spec)
         {
             SpecName = "WardenSpec";
             Is2H = false;
@@ -22,8 +22,14 @@ namespace DOL.GS.Scripts
                 case 0: WeaponOneType = eObjectType.Blades; break;
                 case 1: WeaponOneType = eObjectType.Blunt; break;
             }
-            
-            int randVariance = Util.Random(3);
+
+            var randVariance = spec switch
+            {
+                eSpecType.NurtureWarden => Util.Random(0, 1),
+                eSpecType.BattleWarden => 2,
+                eSpecType.RegrowthWarden => 3,
+                _ => Util.Random(3),
+            };
    
             switch (randVariance)
             {
@@ -36,19 +42,19 @@ namespace DOL.GS.Scripts
                 break;
 
                 case 1:
-                SpecType = eSpecType.BattleWarden;
-                Add(ObjToSpec(WeaponOneType), 39, 0.7f);
-                Add(Specs.Nurture, 49, 0.9f);
-                Add(Specs.Regrowth, 16, 0.3f);
-                Add(Specs.Parry, 12, 0.1f);
-                break;
-
-                case 2:
                 SpecType = eSpecType.NurtureWarden;
                 Add(ObjToSpec(WeaponOneType), 34, 0.3f);
                 Add(Specs.Nurture, 49, 0.9f);
                 Add(Specs.Regrowth, 26, 0.4f);
                 Add(Specs.Parry, 10, 0.0f);
+                break;
+
+                case 2:
+                SpecType = eSpecType.BattleWarden;
+                Add(ObjToSpec(WeaponOneType), 39, 0.7f);
+                Add(Specs.Nurture, 49, 0.9f);
+                Add(Specs.Regrowth, 16, 0.3f);
+                Add(Specs.Parry, 12, 0.1f);
                 break;
 
                 case 3:

--- a/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Bonedancer.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Bonedancer.cs
@@ -10,15 +10,21 @@ namespace DOL.GS.Scripts
 
     public class BonedancerSpec : MimicSpec
     {
-        public BonedancerSpec()
+        public BonedancerSpec(eSpecType spec)
         {
             SpecName = "BonedancerSpec";
 
             WeaponOneType = eObjectType.Staff;
             Is2H = true;
 
-            int randVariance = Util.Random(5);
-            
+            var randVariance = spec switch
+            {
+                eSpecType.SuppBone => Util.Random(0, 2),
+                eSpecType.DarkBone => Util.Random(3, 4),
+                eSpecType.ArmyBone => 5,
+                _ => Util.Random(5),
+            };
+
             switch (randVariance)
             {
                 case 0:

--- a/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Healer.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Healer.cs
@@ -8,14 +8,20 @@
 
     public class HealerSpec : MimicSpec
     {
-        public HealerSpec()
+        public HealerSpec(eSpecType spec)
         {
             SpecName = "HealerSpec";
 
             WeaponOneType = eObjectType.Hammer;
             Is2H = Util.RandomBool();
 
-            int randVariance = Util.Random(10);
+            var randVariance = spec switch
+            {
+                eSpecType.PacHealer => Util.Random(0, 5),
+                eSpecType.MendHealer => Util.Random(6, 8),
+                eSpecType.AugHealer => Util.Random(9, 10),
+                _ => Util.Random(10),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Runemaster.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Runemaster.cs
@@ -10,14 +10,20 @@ namespace DOL.GS.Scripts
 
     public class RunemasterSpec : MimicSpec
     {
-        public RunemasterSpec()
+        public RunemasterSpec(eSpecType spec)
         {
             SpecName = "RunemasterSpec";
 
             WeaponOneType = eObjectType.Staff;
             Is2H = true;
 
-            int randVariance = Util.Random(7);
+            var randVariance = spec switch
+            {
+                eSpecType.DarkRune => Util.Random(0, 1),
+                eSpecType.RuneRune => Util.Random(2, 4),
+                eSpecType.SuppRune => Util.Random(5, 7),
+                _ => Util.Random(7),
+            };
             
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Savage.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Savage.cs
@@ -10,11 +10,17 @@ namespace DOL.GS.Scripts
 
     public class SavageSpec : MimicSpec
     {
-        public SavageSpec()
+        public SavageSpec(eSpecType spec)
         {
             SpecName = "SavageSpec";
 
-            int randBaseWeap = Util.Random(4);
+            var randBaseWeap = spec switch
+            {
+                eSpecType.TwoHanded => Util.Random(0, 2),
+                eSpecType.Mid => Util.Random(0, 2),
+                eSpecType.DualWield => Util.Random(3, 4),
+                _ => Util.Random(4),
+            };
 
             switch (randBaseWeap)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Shadowblade.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Shadowblade.cs
@@ -10,7 +10,7 @@ namespace DOL.GS.Scripts
 
     public class ShadowbladeSpec : MimicSpec
     {
-        public ShadowbladeSpec()
+        public ShadowbladeSpec(eSpecType spec)
         {
             SpecName = "ShadowbladeSpec";
 
@@ -24,7 +24,14 @@ namespace DOL.GS.Scripts
 
             WeaponTwoType = eObjectType.Axe;
 
-            int randVariance = Util.Random(4);
+            var randVariance = spec switch
+            {
+                eSpecType.DualWield => Util.Random(0, 3),
+                eSpecType.LeftAxe => Util.Random(0, 3),
+                eSpecType.TwoHanded => 4,
+                eSpecType.Mid => 4,
+                _ => Util.Random(4),
+            };
 
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Shaman.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Shaman.cs
@@ -10,14 +10,20 @@ namespace DOL.GS.Scripts
 
     public class ShamanSpec : MimicSpec
     {
-        public ShamanSpec()
+        public ShamanSpec(eSpecType spec)
         {
             SpecName = "ShamanSpec";
 
             WeaponOneType = eObjectType.Hammer;
             Is2H = Util.RandomBool();
 
-            int randVariance = Util.Random(7);
+            var randVariance = spec switch
+            {
+                eSpecType.AugShaman => Util.Random(0, 4),
+                eSpecType.SubtShaman => Util.Random(5, 6),
+                eSpecType.MendShaman => 7,
+                _ => Util.Random(7),
+            };
             
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Spiritmaster.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Spiritmaster.cs
@@ -10,13 +10,19 @@ namespace DOL.GS.Scripts
 
     public class SpiritmasterSpec : MimicSpec
     {
-        public SpiritmasterSpec()
+        public SpiritmasterSpec(eSpecType spec)
         {
             SpecName = "SpiritmasterSpec";
             
             WeaponOneType = eObjectType.Staff;
 
-            int randVariance = Util.Random(9);
+            var randVariance = spec switch
+            {
+                eSpecType.DarkSpirit => Util.Random(0, 3),
+                eSpecType.SuppSpirit => Util.Random(4, 7),
+                eSpecType.SummSpirit => Util.Random(8, 9),
+                _ => Util.Random(9),
+            };
             
             switch (randVariance)
             {

--- a/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Thane.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Thane.cs
@@ -10,7 +10,7 @@ namespace DOL.GS.Scripts
 
     public class ThaneSpec : MimicSpec
     {
-        public ThaneSpec()
+        public ThaneSpec(eSpecType spec)
         {
             SpecName = "ThaneSpec";
 
@@ -23,7 +23,14 @@ namespace DOL.GS.Scripts
                 case 2: WeaponOneType = eObjectType.Hammer; break;
             }
 
-            int randVariance = Util.Random(3);
+            var randVariance = spec switch
+            {
+                eSpecType.OneHanded => Util.Random(0, 2),
+                eSpecType.OneHandAndShield => Util.Random(0,2),
+                eSpecType.OneHandHybrid => Util.Random(0, 2),
+                eSpecType.TwoHanded => 3,
+                _ => Util.Random(3),
+            };
 
             SpecType = eSpecType.Mid;
 

--- a/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Warrior.cs
+++ b/GameServer/custom/MimicNPC/ClassSpecs/Midgard/Warrior.cs
@@ -33,12 +33,14 @@ namespace DOL.GS.Scripts
                 Add(ObjToSpec(WeaponOneType), 50, 0.8f);
                 Add(Specs.Shields, 42, 0.5f);
                 Add(Specs.Parry, 39, 0.2f);
+                Add(Specs.Thrown_Weapons, 13, 0.0f);
                 break;
 
                 case 1:
                 Add(ObjToSpec(WeaponOneType), 50, 0.8f);
                 Add(Specs.Shields, 50, 0.5f);
                 Add(Specs.Parry, 28, 0.2f);
+                Add(Specs.Thrown_Weapons, 13, 0.0f);
                 break;
             }
         }

--- a/GameServer/custom/MimicNPC/Commands.cs
+++ b/GameServer/custom/MimicNPC/Commands.cs
@@ -12,44 +12,80 @@ namespace DOL.GS.Scripts
     #region Admin/GM/Debug/Cheats
 
     [CmdAttribute(
-    "&m",
+    "&mcreate",
     ePrivLevel.Player,
-    "/m - Create a mimic of a certain class at your position or ground target.")]
-    public class SummonCommandHandler : AbstractCommandHandler, ICommandHandler
+    "/mcreate class [level] [class] [spec] [inv] - Create a mimic of a certain level, class, and weapon handedness at your position or ground target, and invite them if desired.")]
+    public class MimicCreateCommandHandler : AbstractCommandHandler, ICommandHandler
     {
+        public static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         public void OnCommand(GameClient client, string[] args)
         {
             if (args.Length > 0)
             {
-                byte level;
+                GamePlayer player = client.Player;
+                eMimicClass mclass;
+                byte level = player.Level;
+                eSpecType mimicSpec = eSpecType.None;
+                bool invite = false;
 
-                if (args.Length > 2)
+                if (args.Length > 1)
                 {
-                    level = byte.Parse(args[2]);
-
-                    if (level < 1 || level > 50)
-                        level = 1;
+                    if (!Enum.TryParse<eMimicClass>(args[1], true, out mclass))
+                    {
+                        player.Out.SendMessage(args[1] + " could not be parsed into a class type", eChatType.CT_Say, eChatLoc.CL_ChatWindow);
+                        return;
+                    }
                 }
                 else
-                    level = client.Player.Level;
-
-                Point3D position = new Point3D(client.Player.X, client.Player.Y, client.Player.Z);
-
-                if (client.Player.GroundTarget != null)
                 {
-                    Point2D playerPos = new Point2D(client.Player.X, client.Player.Y);
-
-                    if (client.Player.GroundTarget.GetDistance(playerPos) < 5000)
-                        position = new Point3D(client.Player.GroundTarget);
+                    player.Out.SendMessage("Class must be specified", eChatType.CT_Say, eChatLoc.CL_ChatWindow);
+                    return;
                 }
 
-                if (position != null)
+                for (int i = 2; i < args.Length; i++)
                 {
-                    string capitalize = char.ToUpper(args[1][0]) + args[1].Substring(1);
-                    eMimicClass mclass = (eMimicClass)Enum.Parse(typeof(eMimicClass), capitalize);
+                    if (args[i].StartsWith("inv", StringComparison.OrdinalIgnoreCase))
+                        invite = true;
+                    else if (byte.TryParse(args[i], out byte newLevel))
+                    {
+                        if (newLevel < 1 || newLevel > player.MaxLevel)
+                        {
+                            player.Out.SendMessage("Level must be between 1 and " + player.MaxLevel, eChatType.CT_Say, eChatLoc.CL_ChatWindow);
+                            return;
+                        }
+                        level = newLevel; // TryParse clobbers it's out value, so we need an intermediate
+                    }
+                    else if (!Enum.TryParse<eSpecType>(args[i], true, out mimicSpec) || mimicSpec == eSpecType.None)
+                    {
+                        player.Out.SendMessage("Could not parse " + args[i], eChatType.CT_Say, eChatLoc.CL_ChatWindow);
+                        return;
+                    }
+                }
 
-                    MimicNPC mimic = MimicManager.GetMimic(mclass, level);
-                    MimicManager.AddMimicToWorld(mimic, position, client.Player.CurrentRegionID);
+                Point3D position = new Point3D(player.X, player.Y, player.Z);
+
+                if (player.GroundTarget != null)
+                {
+                    Point2D playerPos = new Point2D(player.X, player.Y);
+
+                    if (client.Player.GroundTarget.GetDistance(playerPos) < 5000)
+                        position = new Point3D(player.GroundTarget);
+                }
+
+                MimicNPC mimic = MimicManager.GetMimic(mclass, level, spec: mimicSpec);
+                MimicManager.AddMimicToWorld(mimic, position, player.CurrentRegionID);
+
+                if (invite && GameServer.ServerRules.IsSameRealm(player, mimic, true))
+                {
+                    if (player.Group == null)
+                    {
+                        player.Group = new Group(player);
+                        player.Group.AddMember(player);
+                    }
+
+                    if (!player.Group.AddMember(mimic))
+                        player.Out.SendMessage("Could not add mimic to group", eChatType.CT_Say, eChatLoc.CL_ChatWindow);
                 }
             }
         }
@@ -59,7 +95,7 @@ namespace DOL.GS.Scripts
        "&mgroup",
        ePrivLevel.Player,
        "/mgroup - To summon a group of mimics from a realm. Args: realm, amount, level")]
-    public class SummonMimicGroupCommandHandler : AbstractCommandHandler, ICommandHandler
+    public class MimicSummonMimicGroupCommandHandler : AbstractCommandHandler, ICommandHandler
     {
         public void OnCommand(GameClient client, string[] args)
         {
@@ -256,7 +292,7 @@ namespace DOL.GS.Scripts
     [CmdAttribute(
    "&mpc",
    ePrivLevel.Player,
-   "/mpc (true/false) - Set PreventCombat on targeted mimic or your group with no target.")]
+   "/mpc (true/false) [group] - Set PreventCombat on targeted mimic or their group, or your group with no target.")]
     public class MimicCombatPreventCommandHandler : AbstractCommandHandler, ICommandHandler
     {
         public void OnCommand(GameClient client, string[] args)
@@ -286,14 +322,15 @@ namespace DOL.GS.Scripts
 
                 if (mimic != null)
                 {
-                    if (mimic.Group != null)
+                    if (args.Length > 2 && args[2].Equals("group", StringComparison.OrdinalIgnoreCase)
+                        && mimic.Group != null)
                     {
                         foreach (GameLiving groupMember in mimic.Group.GetMembersInTheGroup())
                         {
                             if (groupMember is MimicNPC mimicNPC)
                             {
                                 mimicNPC.MimicBrain.PreventCombat = toggle;
-                                message = "PreventCombat for " + mimicNPC.Name + " is " + toggle;
+                                message = "PreventCombat for " + mimicNPC.Name + "'s group is " + toggle;
                             }
                         }
                     }
@@ -320,10 +357,36 @@ namespace DOL.GS.Scripts
     }
 
     [CmdAttribute(
-      "&mbattle",
-      ePrivLevel.Player,
-      "/mbattle [Region] (Start/Stop/Clear>)",
-      "Regions: Thid. Start - Start spawning. Stop - Stop spawning. Clear - Stop and remove mimics.")]
+    "&mheal",
+    ePrivLevel.Player,
+    "/mheal - Toggle whether a mimic will engage in combat or stay back and focus on healing spells")]
+    public class MimicHealCommandHandler : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player.TargetObject is MimicNPC mimic)
+            {
+                if (mimic.Group == null)
+                    mimic.Whisper(client.Player, "I need to be a in a group");
+                else if (!mimic.CanCastHealSpells && !mimic.CanCastInstantHealSpells)
+                    mimic.Whisper(client.Player, "I cannot cast healing spells");
+                else
+                {
+                    mimic.MimicBrain.IsHealer = !mimic.MimicBrain.IsHealer;
+                    if (mimic.MimicBrain.IsHealer)
+                        mimic.Group.SendMessageToGroupMembers(mimic, "I will stay out of combat and focus on healing", eChatType.CT_Group, eChatLoc.CL_ChatWindow);
+                    else
+                        mimic.Group.SendMessageToGroupMembers(mimic, "I will engage in combat", eChatType.CT_Group, eChatLoc.CL_ChatWindow);
+                }
+            }
+        }
+    }
+
+    [CmdAttribute(
+    "&mbattle",
+    ePrivLevel.Player,
+    "/mbattle [Region] (Start/Stop/Clear>)",
+    "Regions: Thid. Start - Start spawning. Stop - Stop spawning. Clear - Stop and remove mimics.")]
     public class MimicBattleCommandHandler : AbstractCommandHandler, ICommandHandler
     {
         public void OnCommand(GameClient client, string[] args)
@@ -352,12 +415,15 @@ namespace DOL.GS.Scripts
       "&msummon",
       ePrivLevel.Player,
       "/msummon - Summons all mimics in your group.")]
-    public class MimimcSummonCommandHandler : AbstractCommandHandler, ICommandHandler
+    public class MimicSummonCommandHandler : AbstractCommandHandler, ICommandHandler
     {
         public void OnCommand(GameClient client, string[] args)
         {
             if (client.Player.Group == null)
                 return;
+
+            client.Player.Group.MimicGroup.SetCampPoint(null);
+            client.Player.Group.MimicGroup.SetPullPoint(null);
 
             foreach (GameLiving groupMember in client.Player.Group.GetMembersInTheGroup())
             {
@@ -367,6 +433,12 @@ namespace DOL.GS.Scripts
                     mimicNPC.MimicBrain.FSM.SetCurrentState(eFSMStateType.WAKING_UP);
                 }
             }
+
+            // We need to update the group members and window, or it breaks selecting group members from the group menus
+            foreach (GameLiving groupMember in client.Player.Group.GetMembersInTheGroup())
+                client.Player.Group.UpdateAllToMember(client.Player, true, false);
+
+            client.Player.Group.UpdateGroupWindow();
         }
     }
 
@@ -378,7 +450,7 @@ namespace DOL.GS.Scripts
        "&mlfg",
        ePrivLevel.Player,
        "/mlfg - Get a list of Mimics that are looking for a group.")]
-    public class LocCommandHandler : AbstractCommandHandler, ICommandHandler
+    public class MimicLfgCommandHandler : AbstractCommandHandler, ICommandHandler
     {
         public void OnCommand(GameClient client, string[] args)
         {
@@ -481,7 +553,7 @@ namespace DOL.GS.Scripts
         "&mrole",
         ePrivLevel.Player,
         "/mrole (leader/tank/assist/cc/puller) - Set the role of a group member.")]
-    public class MainRoleCommandHandler : AbstractCommandHandler, ICommandHandler
+    public class MimicRoleCommandHandler : AbstractCommandHandler, ICommandHandler
     {
         public void OnCommand(GameClient client, string[] args)
         {
@@ -515,8 +587,8 @@ namespace DOL.GS.Scripts
     [CmdAttribute(
         "&mcamp",
         ePrivLevel.Player,
-        "/mcamp (set/remove/aggrorange/filter)- Set where the group camp point is, remove the camp point, the range the group will aggro, and the con level the puller will pull.")]
-    public class CampCommandHandler : AbstractCommandHandler, ICommandHandler
+        "/mcamp (here/set/remove/aggrorange/filter)- Set where the group camp point is, remove the camp point, the range the group will aggro, and the con level the puller will pull.")]
+    public class MimicCampCommandHandler : AbstractCommandHandler, ICommandHandler
     {
         public void OnCommand(GameClient client, string[] args)
         {
@@ -532,6 +604,14 @@ namespace DOL.GS.Scripts
 
                 switch (args[1])
                 {
+                    case "here":
+                        player.Group.MimicGroup.SetCampPoint(new Point3D(player.X, player.Y, player.Z));
+                        player.Out.SendMessage("Camp point set to your location.", eChatType.CT_Say, eChatLoc.CL_SystemWindow);
+
+                        foreach (GameLiving groupMember in player.Group.GetMembersInTheGroup())
+                            if (groupMember is MimicNPC mimic)
+                                mimic.Brain.FSM.SetCurrentState(eFSMStateType.CAMP);
+                        break;
                     case "set":
                     {
                         if (target == null || player.GetDistance(player.GroundTarget) > 2000)
@@ -619,10 +699,47 @@ namespace DOL.GS.Scripts
     }
 
     [CmdAttribute(
+     "&mpull",
+     ePrivLevel.Player,
+     "/mpull - Set camp and pull points to your location, and have puller pull your target")]
+    public class MimicPullCommandHandler : AbstractCommandHandler, ICommandHandler
+    {
+        public static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        public void OnCommand(GameClient client, string[] args)
+        {
+            var player = client.Player;
+
+            if (player.TargetObject is not GameNPC target || !GameServer.ServerRules.IsAllowedToAttack(player, target, true))
+                player.Out.SendMessage("Your target cannot be pulled", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+            else if (player.Group?.MimicGroup is not MimicGroup mGroup)
+                player.Out.SendMessage("You must be grouped with a mimic to use /mpull", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+            else if (mGroup.MainPuller is not MimicNPC puller || puller.Brain is not MimicBrain brainPuller)
+                player.Out.SendMessage("You must assign a puller to use /mpull", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+            else if (puller.Inventory.GetItem(eInventorySlot.DistanceWeapon) == null)
+                puller.Whisper(player, "I do not have a ranged weapon equipped");
+            else
+            {
+                mGroup.SetCampPoint(new Point3D(player.X, player.Y, player.Z));
+                mGroup.SetPullPoint(new Point2D(player.X, player.Y));
+                    
+                foreach (GameLiving groupMember in player.Group.GetMembersInTheGroup())
+                    if (groupMember is MimicNPC mimic)
+                        mimic.Brain.FSM.SetCurrentState(eFSMStateType.CAMP);
+
+                mGroup.ConLevelFilter = puller.GetConLevel(target);
+                puller.TargetObject = target;
+                brainPuller.LastTargetObject = null;
+                brainPuller.PerformPull(target);
+            }
+        }
+    }
+
+    [CmdAttribute(
         "&mpullfrom",
         ePrivLevel.Player,
-        "/mpullfrom (set/remove) - Set where the group puller should try to pull from.")]
-    public class PullFromCommandHandler : AbstractCommandHandler, ICommandHandler
+        "/mpullfrom (here/set/remove) - Set where the group puller should try to pull from.")]
+    public class MimicPullFromCommandHandler : AbstractCommandHandler, ICommandHandler
     {
         public void OnCommand(GameClient client, string[] args)
         {
@@ -638,13 +755,16 @@ namespace DOL.GS.Scripts
 
                 switch (args[1])
                 {
+                    case "here":
+                        player.Group.MimicGroup.SetPullPoint(new Point2D(player.X, player.Y));
+                        player.Out.SendMessage("Pull point set to your location.", eChatType.CT_Say, eChatLoc.CL_SystemWindow);
+                        break;
                     case "set":
                     {
                         if (target == null || !player.GroundTargetInView)
                             return;
 
                         player.Group.MimicGroup.SetPullPoint(target);
-
                         player.Out.SendMessage("Set position to pull from.", eChatType.CT_Say, eChatLoc.CL_SystemWindow);
                     }
                     break;
@@ -652,7 +772,6 @@ namespace DOL.GS.Scripts
                     case "remove":
                     {
                         player.Group.MimicGroup.SetPullPoint(null);
-
                         player.Out.SendMessage("Removed position to pull from.", eChatType.CT_Say, eChatLoc.CL_SystemWindow);
                     }
                     break;
@@ -662,10 +781,110 @@ namespace DOL.GS.Scripts
     }
 
     [CmdAttribute(
-        "&mguard",
-        ePrivLevel.Player,
-        "/mguard [target name] - Set a target to guard.")]
-    public class GuardCommandHandler : AbstractCommandHandler, ICommandHandler
+    "&mfollow",
+    ePrivLevel.Player,
+    "/mfollow - Clear camp and pull points, and have all grouped mimics follow you")]
+    public class MimicFollowCommandHandler : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player.Group != null)
+            {
+                client.Player.Group.MimicGroup.SetCampPoint(null);
+                client.Player.Group.MimicGroup.SetPullPoint(null);
+
+                foreach (GameLiving groupMember in client.Player.Group.GetMembersInTheGroup())
+                    if (groupMember is MimicNPC mimic)
+                        mimic.Brain.FSM.SetCurrentState(eFSMStateType.FOLLOW_THE_LEADER);
+            }
+        }
+    }
+
+    [CmdAttribute(
+    "&mattack",
+    ePrivLevel.Player,
+    "/mattack - Have all grouped mimics attack your target")]
+    public class MimicAttackCommandHandler : AbstractCommandHandler, ICommandHandler
+    {
+        public static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        public void OnCommand(GameClient client, string[] args)
+        {
+            if (client.Player.Group != null && client.Player.TargetObject is GameLiving target)
+                foreach (GameLiving groupMember in client.Player.Group.GetMembersInTheGroup())
+                    if (groupMember is MimicNPC mimic && mimic.Brain is MimicBrain brain 
+                        && !brain.PreventCombat && !brain.IsHealer)
+                    {
+                        brain.AddToAggroList(target, brain.GetMaxAggro() + 1);
+                        brain.AttackMostWanted();
+                     }
+        }
+    }
+
+    [CmdAttribute(
+   "&mintercept",
+   ePrivLevel.Player,
+   "/mintercept [name/class] - Set a target to intercept.")]
+    public class MimicInterceptCommandHandler : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            GamePlayer player = client.Player;
+            MimicNPC target = player.TargetObject as MimicNPC;
+
+            if (target == null || player.Group == null || (player.Group != null && !player.Group.IsInTheGroup(target)))
+                return;
+
+            if (!target.HasAbility(Abilities.Intercept))
+            {
+                target.Whisper(player, "I do not have that ability.");
+                return;
+            }
+
+            GameLiving targetGroupMember = null;
+
+            if (args.Length > 1)
+            {
+                args[1] = args[1].ToLower();
+
+                eCharacterClass charClass = eCharacterClass.Unknown;
+                Enum.TryParse<eCharacterClass>(args[1], true, out charClass);
+
+                foreach (GameLiving groupMember in player.Group.GetMembersInTheGroup())
+                {
+                    if (groupMember != target &&
+                        ((groupMember.Name.Equals(args[1], StringComparison.OrdinalIgnoreCase))
+                        || (groupMember is MimicNPC mimic && mimic.CharacterClass.ID == (int)charClass)
+                        || (groupMember is GamePlayer play && play.CharacterClass.ID == (int)charClass)))
+                    {
+                        targetGroupMember = groupMember;
+                        break;
+                    }
+                }
+
+                if (targetGroupMember != null)
+                {
+                    if (target.MimicBrain.SetIntercept(targetGroupMember, out bool ourEffect))
+                        target.Group.SendMessageToGroupMembers(target, "I will intercept for " + targetGroupMember.Name, eChatType.CT_Group, eChatLoc.CL_ChatWindow);
+                    else
+                    {
+                        if (ourEffect)
+                            target.Group.SendMessageToGroupMembers(target, "I will stop intercepting for " + targetGroupMember.Name, eChatType.CT_Group, eChatLoc.CL_ChatWindow);
+                        else
+                            target.Group.SendMessageToGroupMembers(targetGroupMember.Name + " is already being intercepting for.", eChatType.CT_Group, eChatLoc.CL_ChatWindow);
+                    }
+                }
+                else
+                    target.Whisper(player, "I could not find " + args[1]);
+            }
+        }
+    }
+
+    [CmdAttribute(
+    "&mguard",
+    ePrivLevel.Player,
+    "/mguard [name/class] - Set a target to guard.")]
+    public class MimicGuardCommandHandler : AbstractCommandHandler, ICommandHandler
     {
         public void OnCommand(GameClient client, string[] args)
         {
@@ -677,7 +896,7 @@ namespace DOL.GS.Scripts
 
             if (!target.HasAbility(Abilities.Guard))
             {
-                player.Out.SendMessage("I do not have that ability.", eChatType.CT_Say, eChatLoc.CL_SystemWindow);
+                target.Whisper(player, "I do not have the guard ability.");
                 return;
             }
 
@@ -687,9 +906,15 @@ namespace DOL.GS.Scripts
             {
                 args[1] = args[1].ToLower();
 
+                eCharacterClass charClass = eCharacterClass.Unknown;
+                Enum.TryParse<eCharacterClass>(args[1], true, out charClass);
+
                 foreach (GameLiving groupMember in player.Group.GetMembersInTheGroup())
                 {
-                    if (groupMember.Name.ToLower() == args[1])
+                    if (groupMember != target &&
+                        ((groupMember.Name.Equals(args[1], StringComparison.OrdinalIgnoreCase))
+                        || (groupMember is MimicNPC mimic && mimic.CharacterClass.ID == (int)charClass)
+                        || (groupMember is GamePlayer play && play.CharacterClass.ID == (int)charClass)))
                     {
                         targetGroupMember = groupMember;
                         break;
@@ -699,21 +924,74 @@ namespace DOL.GS.Scripts
                 if (targetGroupMember != null)
                 {
                     if (target.MimicBrain.SetGuard(targetGroupMember, out bool ourEffect))
-                    {
-                        player.Out.SendMessage("I will guard " + args[1], eChatType.CT_Say, eChatLoc.CL_SystemWindow);
-                    }
+                        target.Group.SendMessageToGroupMembers(target, "I will guard " + targetGroupMember.Name, eChatType.CT_Group, eChatLoc.CL_ChatWindow);
                     else
                     {
                         if (ourEffect)
-                            player.Out.SendMessage("I will stop guarding " + args[1], eChatType.CT_Say, eChatLoc.CL_SystemWindow);
+                            target.Group.SendMessageToGroupMembers(target, "I will stop guarding " + targetGroupMember.Name, eChatType.CT_Group, eChatLoc.CL_ChatWindow);
                         else
-                            player.Out.SendMessage(args[1] + " is already being guarded.", eChatType.CT_Say, eChatLoc.CL_SystemWindow);
+                            target.Group.SendMessageToGroupMembers(targetGroupMember.Name + " is already being guarded.", eChatType.CT_Group, eChatLoc.CL_ChatWindow);
                     }
                 }
                 else
+                    target.Whisper(player, "I could not find " + args[1]);
+            }
+        }
+    }
+
+    [CmdAttribute(
+    "&mprotect",
+    ePrivLevel.Player,
+    "/mprotect [name/class] - Set a target to protect.")]
+    public class MimicProtectCommandHandler : AbstractCommandHandler, ICommandHandler
+    {
+        public void OnCommand(GameClient client, string[] args)
+        {
+            GamePlayer player = client.Player;
+            MimicNPC target = player.TargetObject as MimicNPC;
+
+            if (target == null || player.Group == null || (player.Group != null && !player.Group.IsInTheGroup(target)))
+                return;
+
+            if (!target.HasAbility(Abilities.Protect))
+            {
+                target.Whisper(player, "I do not have the protect ability.");
+                return;
+            }
+
+            GameLiving targetGroupMember = null;
+
+            if (args.Length > 1)
+            {
+                eCharacterClass charClass = eCharacterClass.Unknown;
+                Enum.TryParse<eCharacterClass>(args[1], true, out charClass);
+
+                foreach (GameLiving groupMember in player.Group.GetMembersInTheGroup())
                 {
-                    player.Out.SendMessage("I could not find " + args[1], eChatType.CT_Say, eChatLoc.CL_SystemWindow);
+                    if (groupMember != target &&
+                        ((groupMember.Name.Equals(args[1], StringComparison.OrdinalIgnoreCase))
+                        || (groupMember is MimicNPC mimic && mimic.CharacterClass.ID == (int)charClass)
+                        || (groupMember is GamePlayer play && play.CharacterClass.ID == (int)charClass)))
+                    {
+                        targetGroupMember = groupMember;
+                        break;
+                    }
                 }
+
+                if (targetGroupMember != null)
+                {
+                    if (target.MimicBrain.SetProtect(targetGroupMember, out bool ourEffect))
+                        target.Group.SendMessageToGroupMembers(target, "I will protect " + targetGroupMember.Name, eChatType.CT_Group, eChatLoc.CL_ChatWindow);
+                    else
+                    {
+                        if (ourEffect)
+                            target.Group.SendMessageToGroupMembers("I will stop protecting " + targetGroupMember.Name, eChatType.CT_Group, eChatLoc.CL_ChatWindow);
+                        else
+                            target.Group.SendMessageToGroupMembers(target, targetGroupMember.Name + " is already being protected.", eChatType.CT_Group, eChatLoc.CL_ChatWindow);
+                    }
+                }
+                else
+                    target.Whisper(player, "I could not find " + args[1]);
             }
         }
     }

--- a/GameServer/custom/MimicNPC/MimicGroup.cs
+++ b/GameServer/custom/MimicNPC/MimicGroup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using DOL.GS.ServerProperties;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -70,8 +70,8 @@ namespace DOL.GS.Scripts
                 return false;
 
             MainLeader = living;
-            living.Say("Follow me! I will now lead the group. Not really though this isn't implemented.");
-
+            living.Group.SendMessageToGroupMembers(living, "Follow me! I will now lead the group. Not really though this isn't implemented.", 
+                PacketHandler.eChatType.CT_Group, PacketHandler.eChatLoc.CL_ChatWindow);
             return true;
         }
 
@@ -81,8 +81,8 @@ namespace DOL.GS.Scripts
                 return false;
 
             MainAssist = living;
-            living.Say("Assist me! I will be the main assist. Not really though this isn't implemented.");
-
+            living.Group.SendMessageToGroupMembers(living, "Assist me! I will be the main assist. Not really though this isn't implemented.",
+                PacketHandler.eChatType.CT_Group, PacketHandler.eChatLoc.CL_ChatWindow);
             return true;
         }
 
@@ -92,7 +92,8 @@ namespace DOL.GS.Scripts
                 return false;
 
             MainTank = living;
-            living.Say("I will tank.");
+            living.Group.SendMessageToGroupMembers(living, "I will tank.",
+                PacketHandler.eChatType.CT_Group, PacketHandler.eChatLoc.CL_ChatWindow);
             return true;
         }
 
@@ -102,8 +103,8 @@ namespace DOL.GS.Scripts
                 return false;
 
             MainCC = living;
-            living.Say("I'll be the main CC.");
-
+            living.Group.SendMessageToGroupMembers(living, "I'll be the main CC.",
+                PacketHandler.eChatType.CT_Group, PacketHandler.eChatLoc.CL_ChatWindow);
             return true;
         }
 
@@ -112,8 +113,18 @@ namespace DOL.GS.Scripts
             if (living == null || living.Inventory.GetItem(eInventorySlot.DistanceWeapon) == null)
                 return false;
 
-            MainPuller = living;
-            living.Say("I'll be the puller.");
+            if (MainPuller == living)
+            {
+                MainPuller = MainLeader;
+                living.Group.SendMessageToGroupMembers(living, "I'll stop pulling.",
+                    PacketHandler.eChatType.CT_Group, PacketHandler.eChatLoc.CL_ChatWindow);
+            }
+            else
+            {
+                MainPuller = living;
+                living.Group.SendMessageToGroupMembers(living, "I'll be the puller.",
+                    PacketHandler.eChatType.CT_Group, PacketHandler.eChatLoc.CL_ChatWindow);
+            }
 
             return true;
         }
@@ -128,8 +139,157 @@ namespace DOL.GS.Scripts
 
         public void SetPullPoint(Point2D point)
         {
-            PullFromPoint = new Point2D(point);
+            if (point != null)
+                PullFromPoint = new Point2D(point);
+            else
+                PullFromPoint = null;
         }
+
+        #region Healing
+
+        /// <summary>Lock before accessing CheckGroupHealth() or related members</summary>
+        public object HealLock = new();
+        /// <summary>How injured is the group as a whole?</summary>
+        public int AmountToHeal { get; private set; }
+        /// <summary>How many group members are below emergency threshold</summary>
+        public int NumNeedEmergencyHealing { get; private set; }
+        /// <summary>How many group members are below healing threshold</summary>
+        public int NumNeedHealing { get; private set; }
+        /// <summary>How many group members are below max health</summary>
+        public int NumInjured { get; private set; }
+        /// <summary>Most injured group member</summary>
+        public GameLiving MemberToHeal { get; private set; }
+        /// <summary>Mezzed group member</summary>
+        public GameLiving MemberToCureMezz { get; private set; }
+        /// <summary>How many group members are diseased?</summary>
+        public int NumNeedCureDisease { get; private set; }
+        /// <summary>Most injured diseased group member</summary>
+        public GameLiving MemberToCureDisease { get; private set; }
+        /// <summary>How many group members are poisoned?</summary>
+        public int NumNeedCurePoison { get; private set; }  
+        /// <summary>Most injured poisoned group member</summary>
+        public GameLiving MemberToCurePoison { get; private set; }
+        /// <summary>Is a group member already casting an instant heal spell?</summary>
+        public bool AlreadyCastInstantHeal;
+        /// <summary>Is a group member already casting a heal over time spell?  Set in MimicBrain.CheckHeals()</summary>
+        public bool AlreadyCastingHoT;
+        /// <summary>Is a group member already casting a health regen spell?</summary>
+        public bool AlreadyCastingRegen;
+        /// <summary>Is a group member already casting a cure mezz spell?</summary>
+        public bool AlreadyCastingCureMezz;
+        /// <summary>Is a group member already casting a cure disease spell?</summary>
+        public bool AlreadyCastingCureDisease;
+        /// <summary>Is a group member already casting a cure poison spell?</summary>
+        public bool AlreadyCastingCurePoison;
+
+        private int m_healthPercent;
+        private int m_diseasePercent;
+        private int m_poisonPercent;
+        private int m_percentCurrent;
+
+        static readonly public int HealThreshold = Properties.NPC_HEAL_THRESHOLD;
+        static readonly public int EmergencyThreshold = HealThreshold / 2;
+
+        private long nextCheckTime = 0;
+        const long checkTimeOffset = 51; // Think() can be called slightly before interval
+
+        /// <summary>Retrieve health and mezz/disease/poison status for the group</summary>
+        /// <param name="checker">Healer checking group status</param>
+        public void CheckGroupHealth(MimicNPC checker)
+        {
+            if (nextCheckTime < GameLoop.GameLoopTime)
+            {
+                nextCheckTime = GameLoop.GameLoopTime + checker.Brain.ThinkInterval - checkTimeOffset;
+
+                AmountToHeal = 0;
+                NumNeedEmergencyHealing = 0;
+                NumNeedHealing = 0;
+                NumInjured = 0;
+                MemberToHeal = null;
+                MemberToCureMezz = null;
+                NumNeedCureDisease = 0;
+                MemberToCureDisease = null;
+                NumNeedCurePoison = 0;
+                MemberToCurePoison = null;
+                AlreadyCastInstantHeal = false;
+                AlreadyCastingHoT = false;
+                AlreadyCastingRegen = false;
+                AlreadyCastingCureMezz = false;
+                AlreadyCastingCureDisease = false;
+                AlreadyCastingCurePoison = false;
+
+                m_healthPercent = 100;
+                m_diseasePercent = 100;
+                m_poisonPercent = 100;
+
+                foreach (GameLiving groupMember in checker.Group.GetMembersInTheGroup())
+                {
+                    if (groupMember != checker && !groupMember.IsWithinRadius(checker, WorldMgr.VISIBILITY_DISTANCE))
+                    // We can only reuse results if everybody is in the same region and reasonably close together
+                        nextCheckTime = 0;
+                    else
+                    {
+                        m_percentCurrent = groupMember.HealthPercent;
+
+                        if (m_percentCurrent < 100)
+                        {
+                            if (m_percentCurrent < EmergencyThreshold)
+                                NumNeedEmergencyHealing++;
+                            else if (m_percentCurrent < HealThreshold)
+                                NumNeedHealing++;
+                            else
+                                NumInjured++;
+
+                            AmountToHeal += groupMember.MaxHealth - groupMember.Health;
+                        }
+
+                        if (m_percentCurrent < m_healthPercent)
+                        {
+                            m_healthPercent = m_percentCurrent;
+                            MemberToHeal = groupMember;
+                        }
+
+                        if (groupMember.IsMezzed && groupMember != null)
+                            MemberToCureMezz = groupMember;
+
+                        if (groupMember.IsDiseased)
+                        {
+                            NumNeedCureDisease++;
+                            if (MemberToCureDisease == null || m_percentCurrent < m_diseasePercent)
+                            {
+                                MemberToCureDisease = groupMember;
+                                m_diseasePercent = m_percentCurrent;
+                            }
+                        }
+
+                        if (groupMember.IsPoisoned)
+                        {
+                            NumNeedCurePoison++;
+                            if (MemberToCurePoison == null || m_percentCurrent < m_poisonPercent)
+                            {
+                                MemberToCurePoison = groupMember;
+                                m_diseasePercent = m_poisonPercent;
+                            }
+                        }
+
+                        if (groupMember.IsCasting)
+                            switch (groupMember.CurrentSpellHandler.Spell.SpellType)
+                            {
+                                case eSpellType.HealOverTime: AlreadyCastingHoT = true; break;
+                                case eSpellType.HealthRegenBuff: AlreadyCastingRegen = true; break;
+                                case eSpellType.CureMezz: AlreadyCastingCureMezz = true; break;
+                                case eSpellType.CureDisease: AlreadyCastingCureDisease = true; break;
+                                case eSpellType.CurePoison: AlreadyCastingCurePoison = true; break;
+                            }
+                    }
+                }
+
+                NumNeedHealing += NumNeedEmergencyHealing;
+                NumInjured += NumNeedHealing;
+            }
+        }
+
+        #endregion
 
         public class QueueRequest
         {

--- a/GameServer/custom/MimicNPC/MimicManager.cs
+++ b/GameServer/custom/MimicNPC/MimicManager.cs
@@ -548,12 +548,12 @@ namespace DOL.GS.Scripts
             return false;
         }
 
-        public static MimicNPC GetMimic(eMimicClass charClass, byte level, string name = "", eGender gender = eGender.Neutral, bool preventCombat = false)
+        public static MimicNPC GetMimic(eMimicClass charClass, byte level, string name = "", eGender gender = eGender.Neutral, eSpecType spec = eSpecType.None, bool preventCombat = false)
         {
             if (charClass == eMimicClass.None)
                 return null;
 
-            MimicNPC mimic = new MimicNPC(charClass, level);
+            MimicNPC mimic = new MimicNPC(charClass, level, gender, spec);
 
             if (mimic != null)
             {
@@ -1070,48 +1070,48 @@ namespace DOL.GS.Scripts
             return spec;
         }
 
-        public static MimicSpec GetSpec(eMimicClass charClass)
+        public static MimicSpec GetSpec(eMimicClass charClass, eSpecType spec = eSpecType.None)
         {
             switch (charClass)
             {
-                case eMimicClass.Armsman: return new ArmsmanSpec();
-                case eMimicClass.Cabalist: return new CabalistSpec();
-                case eMimicClass.Cleric: return new ClericSpec();
-                case eMimicClass.Friar: return new FriarSpec();
+                case eMimicClass.Armsman: return new ArmsmanSpec(spec);
+                case eMimicClass.Cabalist: return new CabalistSpec(spec);
+                case eMimicClass.Cleric: return new ClericSpec(spec);
+                case eMimicClass.Friar: return new FriarSpec(spec);
                 case eMimicClass.Infiltrator: return new InfiltratorSpec();
-                case eMimicClass.Mercenary: return new MercenarySpec();
+                case eMimicClass.Mercenary: return new MercenarySpec(spec);
                 case eMimicClass.Minstrel: return new MinstrelSpec();
-                case eMimicClass.Paladin: return new PaladinSpec();
+                case eMimicClass.Paladin: return new PaladinSpec(spec);
                 case eMimicClass.Reaver: return new ReaverSpec();
                 case eMimicClass.Scout: return new ScoutSpec();
-                case eMimicClass.Sorcerer: return new SorcererSpec();
-                case eMimicClass.Theurgist: return new TheurgistSpec();
-                case eMimicClass.Wizard: return new WizardSpec();
+                case eMimicClass.Sorcerer: return new SorcererSpec(spec);
+                case eMimicClass.Theurgist: return new TheurgistSpec(spec);
+                case eMimicClass.Wizard: return new WizardSpec(spec);
 
                 case eMimicClass.Bard: return new BardSpec();
-                case eMimicClass.Blademaster: return new BlademasterSpec();
-                case eMimicClass.Champion: return new ChampionSpec();
-                case eMimicClass.Druid: return new DruidSpec();
-                case eMimicClass.Eldritch: return new EldritchSpec();
-                case eMimicClass.Enchanter: return new EnchanterSpec();
-                case eMimicClass.Hero: return new HeroSpec();
-                case eMimicClass.Mentalist: return new MentalistSpec();
+                case eMimicClass.Blademaster: return new BlademasterSpec(spec);
+                case eMimicClass.Champion: return new ChampionSpec(spec);
+                case eMimicClass.Druid: return new DruidSpec(spec);
+                case eMimicClass.Eldritch: return new EldritchSpec(spec);
+                case eMimicClass.Enchanter: return new EnchanterSpec(spec);
+                case eMimicClass.Hero: return new HeroSpec(spec);
+                case eMimicClass.Mentalist: return new MentalistSpec(spec);
                 case eMimicClass.Nightshade: return new NightshadeSpec();
                 case eMimicClass.Ranger: return new RangerSpec();
                 case eMimicClass.Valewalker: return new ValewalkerSpec();
-                case eMimicClass.Warden: return new WardenSpec();
+                case eMimicClass.Warden: return new WardenSpec(spec);
 
                 case eMimicClass.Berserker: return new BerserkerSpec();
-                case eMimicClass.Bonedancer: return new BonedancerSpec();
-                case eMimicClass.Healer: return new HealerSpec();
+                case eMimicClass.Bonedancer: return new BonedancerSpec(spec);
+                case eMimicClass.Healer: return new HealerSpec(spec);
                 case eMimicClass.Hunter: return new HunterSpec();
-                case eMimicClass.Runemaster: return new RunemasterSpec();
-                case eMimicClass.Savage: return new SavageSpec();
-                case eMimicClass.Shadowblade: return new ShadowbladeSpec();
-                case eMimicClass.Shaman: return new ShamanSpec();
+                case eMimicClass.Runemaster: return new RunemasterSpec(spec);
+                case eMimicClass.Savage: return new SavageSpec(spec);
+                case eMimicClass.Shadowblade: return new ShadowbladeSpec(spec);
+                case eMimicClass.Shaman: return new ShamanSpec(spec);
                 case eMimicClass.Skald: return new SkaldSpec();
-                case eMimicClass.Spiritmaster: return new SpiritmasterSpec();
-                case eMimicClass.Thane: return new ThaneSpec();
+                case eMimicClass.Spiritmaster: return new SpiritmasterSpec(spec);
+                case eMimicClass.Thane: return new ThaneSpec(spec);
                 case eMimicClass.Warrior: return new WarriorSpec();
             }
 


### PR DESCRIPTION
I modified and added commands to support summoning a group of mimics to go romp in dungeons with.  That includes selecting spec type when creating mimics, a command to set a mimic to not engage in combat and focus on healing, commands to simplify pulling and break camp, and commands for the protect and intercept abilities.

Healing is now a lot more complex, and includes curing disease/mezz/poison.  It's a lot, and I've tried to make it as readable and efficient as possible.  I primarily tested cure functionality using Droom, and it works well both when there's only a single dedicated healer, and when there are secondary healers like mentalists, friars, or wardens.

This probably should have been two separate PRs.  I had no idea how complicated healing was going to get when I started testing the new /mheal command.