### PR TITLE
Mimic pet improvements: healing, buffing, and loot credit

### DIFF
--- a/GameServer/custom/MimicNPC/MimicGroup.cs
+++ b/GameServer/custom/MimicNPC/MimicGroup.cs
@@ -281,6 +281,30 @@ namespace DOL.GS.Scripts
                                 case eSpellType.CureDisease: AlreadyCastingCureDisease = true; break;
                                 case eSpellType.CurePoison: AlreadyCastingCurePoison = true; break;
                             }
+
+                        // Check group member's pet health
+                        if (groupMember.ControlledBrain?.Body is GameLiving pet && pet.IsAlive)
+                        {
+                            m_percentCurrent = pet.HealthPercent;
+
+                            if (m_percentCurrent < 100)
+                            {
+                                if (m_percentCurrent < EmergencyThreshold)
+                                    NumNeedEmergencyHealing++;
+                                else if (m_percentCurrent < HealThreshold)
+                                    NumNeedHealing++;
+                                else
+                                    NumInjured++;
+
+                                AmountToHeal += pet.MaxHealth - pet.Health;
+                            }
+
+                            if (m_percentCurrent < m_healthPercent)
+                            {
+                                m_healthPercent = m_percentCurrent;
+                                MemberToHeal = pet;
+                            }
+                        }
                     }
                 }
 

--- a/GameServer/custom/MimicNPC/ai/MimicBrain.cs
+++ b/GameServer/custom/MimicNPC/ai/MimicBrain.cs
@@ -2742,6 +2742,24 @@ namespace DOL.AI.Brain
                                     }
                                 }
                             }
+
+                            // Buff group member pets
+                            if (target == null && spell.Target != eSpellTarget.SELF)
+                            {
+                                foreach (GameLiving groupMember in Body.Group.GetMembersInTheGroup())
+                                {
+                                    if (groupMember != Body
+                                        && groupMember.ControlledBrain?.Body is GameLiving pet
+                                        && pet.IsAlive
+                                        && Body.GetDistanceTo(pet) <= spell.Range
+                                        && !LivingHasEffect(pet, spell)
+                                        && !Body.attackComponent.AttackState)
+                                    {
+                                        target = pet;
+                                        break;
+                                    }
+                                }
+                            }
                         }
                     }
 

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -2896,6 +2896,10 @@ namespace DOL.GS
                     if (killer is GameNPC pet && pet.Brain is IControlledBrain petBrain)
                         killer = petBrain.GetLivingOwner();
 
+
+                    // If a mimic got the kill, resolve to the group's player leader for loot purposes
+                    if (killer is MimicNPC mimic && mimic.Group?.LivingLeader is GamePlayer playerLeader)
+                        killer = playerLeader;
                     Diagnostics.StartPerfCounter($"ReaperService-NPC-ProcessDeath-DropLoot-NPC({hashCode})");
 
                     if (IsWorthReward)


### PR DESCRIPTION
I've really enjoyed your bot enhancement. I thought I'd make a contribution, in case you're interested. This is my first entry into the OpenDAoC codebase, and the first `C#` code I've written in decades. For that reason alone, feel free to ignore this.

If you're still making updates, here are some things I did for my own use case, which is all about solo reminiscing with my own private server and finding excuses to write code.

## Purpose of the changes

I wanted to see if I could buff and heal an enchanter pet with a mimic mentalist and warden, and I got it working. In this commit are two fixes for mimic group behavior involving pets.

### Heal and buff group member pets

Mimics will no longer ignore the pets of their group members when evaluating healing targets and buff candidates. 

- MimicGroup.cs: Pet health is now checked alongside group member health during the group health scan. Pets are included in the emergency/heal/injured counts and can be selected as MemberToHeal.
- MimicBrain.cs: When a mimic has no buff target among group members, it now checks group member pets as candidates (respecting range, alive state, and existing effects).

### Credit player for mimic kills

When a mimic lands the killing blow on a mob, loot was being lost because the loot system didn't recognize the mimic as a valid recipient. The kill is now resolved to the group's player leader so loot drops correctly.

- GameNPC.cs: Added a killer resolution step in ProcessDeath that maps mimic killers to their group's GamePlayer leader, similar to how pet kills are already resolved to their owner.